### PR TITLE
Improve .gitignore and clean up tracked IDE artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,63 @@
-**/target
-.bloop
-.metals
-.vscode
-.idea
-.bsp
-**/project/metals.sbt
+# Build outputs
+**/target/
+**/project/target/
+
+# IDE files
+.bloop/
+.metals/
+.vscode/
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# Build tool cache
+.bsp/
+
+# Metals LSP
+**/metals.sbt
+project/metals.sbt
 project/project/metals.sbt
 project/project/project/metals.sbt
+
+# OS files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.temp
+*~
+*.swp
+*.swo
+
+# Logs
+*.log
+
+# Environment and secrets
 .envrc
+.env
+.env.local
+.env.*.local
+
+# Upload artifacts
 .upload.json
-*/metals.sbt
+
+# Scala worksheet
+*.sc
+
+# Ensime
+.ensime
+.ensime_cache/
+
+# Dotty-specific
+.dotty-ide-artifact
+.dotty-ide.json
+
+# Coursier cache
+.coursier/

--- a/project/project/metals.sbt
+++ b/project/project/metals.sbt
@@ -1,8 +1,0 @@
-// format: off
-// DO NOT EDIT! This file is auto-generated.
-
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.13")
-
-// format: on

--- a/project/project/project/metals.sbt
+++ b/project/project/project/metals.sbt
@@ -1,8 +1,0 @@
-// format: off
-// DO NOT EDIT! This file is auto-generated.
-
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.13")
-
-// format: on


### PR DESCRIPTION
## Summary

• Updated .gitignore with comprehensive Scala project patterns for better build artifact and IDE file management
• Removed auto-generated metals.sbt files that were incorrectly tracked in the repository
• Enhanced project maintainability by preventing future IDE-specific files from being committed

## Changes Made

### Updated .gitignore
- Added comprehensive build output patterns (`**/target/`, `**/project/target/`)
- Enhanced IDE file exclusions (IntelliJ, VS Code, Metals, Ensime)
- Added OS-specific file patterns (macOS, Windows, Linux)
- Included temporary file patterns (swap files, logs, worksheets)
- Added environment file patterns and security-sensitive files
- Improved Scala-specific patterns (Dotty, Coursier cache)

### Cleaned Up Repository
- Removed `project/project/metals.sbt` - auto-generated Metals LSP file
- Removed `project/project/project/metals.sbt` - nested auto-generated file

## Benefits

- **Cleaner repository**: IDE-specific files and build artifacts will no longer pollute the git history
- **Better collaboration**: Team members using different IDEs won't accidentally commit their local configuration files
- **Reduced merge conflicts**: Auto-generated files won't cause unnecessary conflicts between developers
- **Security improvement**: Environment files and secrets are now properly ignored
- **Maintenance reduction**: Less manual cleanup of accidentally committed temporary files

These changes align with Scala project best practices and will improve the development experience for all contributors.